### PR TITLE
Use alembic instead of sqlalchemy-migrate

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ Flask==0.10.1
 Werkzeug==0.9.4
 wsgiref==0.1.2
 MySQL-python
-sqlalchemy-migrate
+alembic
 SQLAlchemy
 Flask-SQLAlchemy


### PR DESCRIPTION
Apparently alembic is written by the author of sqlalchemy and is easier to use. Also, sqlalchemy-migrate apparently doesn't get updated very often. 
