### PR TITLE
continue loading data even if some scenarios do not match

### DIFF
--- a/ratechecker/management/commands/load_daily_data.py
+++ b/ratechecker/management/commands/load_daily_data.py
@@ -558,7 +558,8 @@ class Command(BaseCommand):
 
         if not passed:
             failed.sort(key=int)
-            raise OaHException("The following scenarios don't match: %s" % failed)
+            self.messages.append("The following scenarios don't match: %s " % failed)
+            #raise OaHException("The following scenarios don't match: %s" % failed)
 
     def archive_data_to_temp_tables(self, cursor):
         """ Save data to temporary tables and delete it from normal tables."""


### PR DESCRIPTION
Because our data provider has trouble communicating us the exact logic it uses to calculate test results we decided not to let it stop us from loading data.