### PR TITLE
Remove commands to create project

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ workon oah
 Create a folder for your Django project in a workspace or other location you like (`~/workspace` in this case):
 ```shell
 cd ~/workspace
-mkdir oah_api && cd oah_api
 pip install django==1.6
 # Create a sample project
 django-admin.py startproject oah_api
+cd oah_api
 ```
 
 Edit `oah_api/settings.py` to use MySQL as the database, edit the `DATABASES` dictionary to the following, and replace the database user name and password (or root if you did not create one) you created above:


### PR DESCRIPTION
Remove the unnecessary step to make a directory.  Because it was creating another layer of folders, (oah_api/oah_api/oah_api in order to access settings.py and other files)