### PR TITLE
Load_Daily_Data: Add more output info for failed scenarios

### DIFF
--- a/ratechecker/management/commands/load_daily_data.py
+++ b/ratechecker/management/commands/load_daily_data.py
@@ -538,7 +538,7 @@ class Command(BaseCommand):
     def compare_scenarios_output(self, precalculated_results):
         """ Run scenarios thru API, compare results to <precalculated_results>."""
         passed = True
-        failed = []
+        failed = {}
         for scenario_no in self.test_scenarios:
             # since these scenarios use loan_type=AGENCY
             if scenario_no in ['16', '42' ]:
@@ -554,11 +554,19 @@ class Command(BaseCommand):
 
                 if expected_rate is not None and api_result['data']:
                     passed = False
-                    failed.append(scenario_no)
+
+                    failed_str = ' scenario_no: ' + str(scenario_no) + \
+                                 ' Expected: ' + str(precalculated_results[scenario_no]) + \
+                                 ' Actual: ' + str(api_result['data']) + "<br>"
+
+                    failed[int(scenario_no)] = failed_str
 
         if not passed:
-            failed.sort(key=int)
-            self.messages.append("The following scenarios don't match: %s " % failed)
+            sorted_failed = []
+            for i in sorted(failed):
+                sorted_failed.append(failed[i])
+
+            self.messages.append("The following scenarios don't match: <br>%s" % sorted_failed)
             #raise OaHException("The following scenarios don't match: %s" % failed)
 
     def archive_data_to_temp_tables(self, cursor):


### PR DESCRIPTION
When there are scenarios mismatch, this will now show the expected and actual results in the output.

This PR is for merging with the latest tag v0.9.6-perf.  You can compare the difference here:
https://github.com/cfpb/owning-a-home-api/compare/cfpb:v0.9.6-perf...amymok:add-info-failed-scenarios

## Changes

- Added expected and actual results for message output


## Review

- @fna