### PR TITLE
Validate the content of API `state` parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
   - pip install -r requirements/test.txt
   - pip install coveralls
 script:
-  - coverage run manage.py test
+  - coverage run manage.py test > /dev/null
 after_success:
   - coveralls
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## 0.9.8 - 2016-10-20
 - Updated djangorestframework from 2.4.3 to 3.1.3
-- bumped Django requirements to 1.8.15 to match cfgov site
+- Bumped Django requirements to 1.8.15 to match cfgov site
+- Added a whitelist check for the countylimit API's `state` querystring parameter
 
 ## 0.9.6 - 2015-01-09
 - continue loading data even if some scenarios do not match

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Owning a Home API 
 
-This project feeds detailed mortgage market data to the Consumer Financial Protection Bureau's [Owning a Home suite of tools](http://www.consumerfinance.gov/owning-a-home/). Unfortunately, the raw data set it serves is not available publicly and is not in this repository. 
+This project feeds detailed mortgage market data to the Consumer Financial Protection Bureau's [Owning a Home suite of tools](http://www.consumerfinance.gov/owning-a-home/). Unfortunately, the raw data set it uses is not available publicly and is not in this repository.
 
 What is included is the API code and some basic geographical data. If you want to give it a spin, here's how:
 
@@ -48,6 +48,7 @@ pip install -r requirements/test.txt
 ```shell
 python manage.py migrate --noinput
 python manage.py load_county_limits ~/workspace/owning-a-home-api/data/county_limit_data-flat.csv --confirm=y
+python manage.py loaddata states
 python manage.py runserver
 ```
 

--- a/countylimits/fixtures/states.json
+++ b/countylimits/fixtures/states.json
@@ -1,0 +1,450 @@
+[
+{
+    "fields": {
+        "state_fips": "01",
+        "state_abbr": "AL"
+    },
+    "model": "countylimits.state",
+    "pk": 225
+},
+{
+    "fields": {
+        "state_fips": "02",
+        "state_abbr": "AK"
+    },
+    "model": "countylimits.state",
+    "pk": 227
+},
+{
+    "fields": {
+        "state_fips": "04",
+        "state_abbr": "AZ"
+    },
+    "model": "countylimits.state",
+    "pk": 229
+},
+{
+    "fields": {
+        "state_fips": "05",
+        "state_abbr": "AR"
+    },
+    "model": "countylimits.state",
+    "pk": 231
+},
+{
+    "fields": {
+        "state_fips": "06",
+        "state_abbr": "CA"
+    },
+    "model": "countylimits.state",
+    "pk": 233
+},
+{
+    "fields": {
+        "state_fips": "08",
+        "state_abbr": "CO"
+    },
+    "model": "countylimits.state",
+    "pk": 235
+},
+{
+    "fields": {
+        "state_fips": "09",
+        "state_abbr": "CT"
+    },
+    "model": "countylimits.state",
+    "pk": 237
+},
+{
+    "fields": {
+        "state_fips": "10",
+        "state_abbr": "DE"
+    },
+    "model": "countylimits.state",
+    "pk": 239
+},
+{
+    "fields": {
+        "state_fips": "11",
+        "state_abbr": "DC"
+    },
+    "model": "countylimits.state",
+    "pk": 241
+},
+{
+    "fields": {
+        "state_fips": "12",
+        "state_abbr": "FL"
+    },
+    "model": "countylimits.state",
+    "pk": 243
+},
+{
+    "fields": {
+        "state_fips": "13",
+        "state_abbr": "GA"
+    },
+    "model": "countylimits.state",
+    "pk": 245
+},
+{
+    "fields": {
+        "state_fips": "15",
+        "state_abbr": "HI"
+    },
+    "model": "countylimits.state",
+    "pk": 247
+},
+{
+    "fields": {
+        "state_fips": "16",
+        "state_abbr": "ID"
+    },
+    "model": "countylimits.state",
+    "pk": 249
+},
+{
+    "fields": {
+        "state_fips": "17",
+        "state_abbr": "IL"
+    },
+    "model": "countylimits.state",
+    "pk": 251
+},
+{
+    "fields": {
+        "state_fips": "18",
+        "state_abbr": "IN"
+    },
+    "model": "countylimits.state",
+    "pk": 253
+},
+{
+    "fields": {
+        "state_fips": "19",
+        "state_abbr": "IA"
+    },
+    "model": "countylimits.state",
+    "pk": 255
+},
+{
+    "fields": {
+        "state_fips": "20",
+        "state_abbr": "KS"
+    },
+    "model": "countylimits.state",
+    "pk": 257
+},
+{
+    "fields": {
+        "state_fips": "21",
+        "state_abbr": "KY"
+    },
+    "model": "countylimits.state",
+    "pk": 259
+},
+{
+    "fields": {
+        "state_fips": "22",
+        "state_abbr": "LA"
+    },
+    "model": "countylimits.state",
+    "pk": 261
+},
+{
+    "fields": {
+        "state_fips": "23",
+        "state_abbr": "ME"
+    },
+    "model": "countylimits.state",
+    "pk": 263
+},
+{
+    "fields": {
+        "state_fips": "24",
+        "state_abbr": "MD"
+    },
+    "model": "countylimits.state",
+    "pk": 265
+},
+{
+    "fields": {
+        "state_fips": "25",
+        "state_abbr": "MA"
+    },
+    "model": "countylimits.state",
+    "pk": 267
+},
+{
+    "fields": {
+        "state_fips": "26",
+        "state_abbr": "MI"
+    },
+    "model": "countylimits.state",
+    "pk": 269
+},
+{
+    "fields": {
+        "state_fips": "27",
+        "state_abbr": "MN"
+    },
+    "model": "countylimits.state",
+    "pk": 271
+},
+{
+    "fields": {
+        "state_fips": "28",
+        "state_abbr": "MS"
+    },
+    "model": "countylimits.state",
+    "pk": 273
+},
+{
+    "fields": {
+        "state_fips": "29",
+        "state_abbr": "MO"
+    },
+    "model": "countylimits.state",
+    "pk": 275
+},
+{
+    "fields": {
+        "state_fips": "30",
+        "state_abbr": "MT"
+    },
+    "model": "countylimits.state",
+    "pk": 277
+},
+{
+    "fields": {
+        "state_fips": "31",
+        "state_abbr": "NE"
+    },
+    "model": "countylimits.state",
+    "pk": 279
+},
+{
+    "fields": {
+        "state_fips": "32",
+        "state_abbr": "NV"
+    },
+    "model": "countylimits.state",
+    "pk": 281
+},
+{
+    "fields": {
+        "state_fips": "33",
+        "state_abbr": "NH"
+    },
+    "model": "countylimits.state",
+    "pk": 283
+},
+{
+    "fields": {
+        "state_fips": "34",
+        "state_abbr": "NJ"
+    },
+    "model": "countylimits.state",
+    "pk": 285
+},
+{
+    "fields": {
+        "state_fips": "35",
+        "state_abbr": "NM"
+    },
+    "model": "countylimits.state",
+    "pk": 287
+},
+{
+    "fields": {
+        "state_fips": "36",
+        "state_abbr": "NY"
+    },
+    "model": "countylimits.state",
+    "pk": 289
+},
+{
+    "fields": {
+        "state_fips": "37",
+        "state_abbr": "NC"
+    },
+    "model": "countylimits.state",
+    "pk": 291
+},
+{
+    "fields": {
+        "state_fips": "38",
+        "state_abbr": "ND"
+    },
+    "model": "countylimits.state",
+    "pk": 293
+},
+{
+    "fields": {
+        "state_fips": "39",
+        "state_abbr": "OH"
+    },
+    "model": "countylimits.state",
+    "pk": 295
+},
+{
+    "fields": {
+        "state_fips": "40",
+        "state_abbr": "OK"
+    },
+    "model": "countylimits.state",
+    "pk": 297
+},
+{
+    "fields": {
+        "state_fips": "41",
+        "state_abbr": "OR"
+    },
+    "model": "countylimits.state",
+    "pk": 299
+},
+{
+    "fields": {
+        "state_fips": "42",
+        "state_abbr": "PA"
+    },
+    "model": "countylimits.state",
+    "pk": 301
+},
+{
+    "fields": {
+        "state_fips": "44",
+        "state_abbr": "RI"
+    },
+    "model": "countylimits.state",
+    "pk": 303
+},
+{
+    "fields": {
+        "state_fips": "45",
+        "state_abbr": "SC"
+    },
+    "model": "countylimits.state",
+    "pk": 305
+},
+{
+    "fields": {
+        "state_fips": "46",
+        "state_abbr": "SD"
+    },
+    "model": "countylimits.state",
+    "pk": 307
+},
+{
+    "fields": {
+        "state_fips": "47",
+        "state_abbr": "TN"
+    },
+    "model": "countylimits.state",
+    "pk": 309
+},
+{
+    "fields": {
+        "state_fips": "48",
+        "state_abbr": "TX"
+    },
+    "model": "countylimits.state",
+    "pk": 311
+},
+{
+    "fields": {
+        "state_fips": "49",
+        "state_abbr": "UT"
+    },
+    "model": "countylimits.state",
+    "pk": 313
+},
+{
+    "fields": {
+        "state_fips": "50",
+        "state_abbr": "VT"
+    },
+    "model": "countylimits.state",
+    "pk": 315
+},
+{
+    "fields": {
+        "state_fips": "51",
+        "state_abbr": "VA"
+    },
+    "model": "countylimits.state",
+    "pk": 317
+},
+{
+    "fields": {
+        "state_fips": "53",
+        "state_abbr": "WA"
+    },
+    "model": "countylimits.state",
+    "pk": 319
+},
+{
+    "fields": {
+        "state_fips": "54",
+        "state_abbr": "WV"
+    },
+    "model": "countylimits.state",
+    "pk": 321
+},
+{
+    "fields": {
+        "state_fips": "55",
+        "state_abbr": "WI"
+    },
+    "model": "countylimits.state",
+    "pk": 323
+},
+{
+    "fields": {
+        "state_fips": "56",
+        "state_abbr": "WY"
+    },
+    "model": "countylimits.state",
+    "pk": 325
+},
+{
+    "fields": {
+        "state_fips": "60",
+        "state_abbr": "AS"
+    },
+    "model": "countylimits.state",
+    "pk": 327
+},
+{
+    "fields": {
+        "state_fips": "66",
+        "state_abbr": "GU"
+    },
+    "model": "countylimits.state",
+    "pk": 329
+},
+{
+    "fields": {
+        "state_fips": "69",
+        "state_abbr": "MP"
+    },
+    "model": "countylimits.state",
+    "pk": 331
+},
+{
+    "fields": {
+        "state_fips": "72",
+        "state_abbr": "PR"
+    },
+    "model": "countylimits.state",
+    "pk": 333
+},
+{
+    "fields": {
+        "state_fips": "78",
+        "state_abbr": "VI"
+    },
+    "model": "countylimits.state",
+    "pk": 335
+}
+]

--- a/countylimits/views.py
+++ b/countylimits/views.py
@@ -1,10 +1,13 @@
-from django.shortcuts import render
-
 from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
-from countylimits.models import CountyLimit
+from countylimits.models import CountyLimit, State
+
+SAFE_STATE_LIST = (  # states can be specified by abbreviation or FIPS code
+    list(State.objects.values_list('state_abbr', flat=True)) +
+    list(State.objects.values_list('state_fips', flat=True))
+    )
 
 
 @api_view(['GET'])
@@ -14,12 +17,16 @@ def county_limits(request):
         package = {'request': {}, 'data': []}
         if 'state' in request.GET:
             state = request.GET['state']
-            data = CountyLimit.county_limits_by_state(state)
-            if data:
-                package['request']['state'] = request.GET['state']
+            if state in SAFE_STATE_LIST:
+                data = CountyLimit.county_limits_by_state(state)
+                package['request']['state'] = state
                 package['data'] = data
                 return Response(package)
             else:
-                return Response({'state': 'Invalid state'}, status=status.HTTP_400_BAD_REQUEST)
+                return Response(
+                    {'state': 'Invalid state'},
+                    status=status.HTTP_400_BAD_REQUEST)
         else:
-            return Response({'detail': 'Required parameter state is missing'}, status=status.HTTP_400_BAD_REQUEST)
+            return Response(
+                {'detail': 'Required parameter state is missing'},
+                status=status.HTTP_400_BAD_REQUEST)

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,4 @@
 Django==1.8.15
 djangorestframework==3.1.3
-MySQL-python
 django-localflavor
 django-cors-headers
-mkdocs==0.15.3
-mkDOCter==1.0.1

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,0 +1,2 @@
+mkdocs==0.15.3
+mkDOCter==1.0.1

--- a/requirements/mysql.txt
+++ b/requirements/mysql.txt
@@ -1,0 +1,3 @@
+-r base.txt
+
+MySQL-python

--- a/settings_for_testing.py
+++ b/settings_for_testing.py
@@ -43,14 +43,15 @@ DATABASES = {
     }
 }
 
-# if using mysql for production data load:
+# '''if using MySQL and a cfgov-refresh production data load:'''
+
 # DATABASES = {
 #     'default': {
 #            'ENGINE': 'django.db.backends.mysql',
-#            'NAME': 'oah',
+#            'NAME': 'v1',
 #            'USER': 'root',
 #            'PASSWORD': '',
-#    }
+#     }
 # }
 
 LANGUAGE_CODE = 'en-us'

--- a/settings_for_testing.py
+++ b/settings_for_testing.py
@@ -35,7 +35,9 @@ ALLOWED_HOSTS = []
 INSTALLED_APPS = ALWAYS_INSTALLED_APPS + CUSTOM_INSTALLED_APPS
 MIDDLEWARE_CLASSES = ALWAYS_MIDDLEWARE_CLASSES
 ROOT_URLCONF = 'oahapi.urls'
-
+FIXTURE_DIRS = [
+    '{}/countylimits/fixtures/'.format(BASE_DIR)
+]
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',


### PR DESCRIPTION
This adds a whitelist check to `state` values ingested by the API.
It also adds a `states.json` fixture for standalone and testing use.

## Review
@willbarton 

- [x] CHANGELOG and README updated