### PR TITLE
Make endpoint error messages safe for round-trips

### DIFF
--- a/ratechecker/ratechecker_parameters.py
+++ b/ratechecker/ratechecker_parameters.py
@@ -5,6 +5,12 @@ from ratechecker.models import Product
 from localflavor.us.us_states import STATE_CHOICES
 
 
+def scrub_error(error):
+    for char in ['<', '>', r'%3C', r'%3E']:
+        error = error.replace(char, '')
+    return error
+
+
 class ParamsSerializer(serializers.Serializer):
 
     PROPERTY_TYPE_SF = 'SF'
@@ -144,3 +150,14 @@ class ParamsSerializer(serializers.Serializer):
             raise serializers.ValidationError("loan_term needs to be "
                                               "15 or 30.")
         return value
+
+    @property
+    def errors(self):
+        if not hasattr(self, '_errors'):
+            msg = 'You must call `.is_valid()` before accessing `.errors`.'
+            raise AssertionError(msg)
+        for key in self._errors.keys():
+            self._errors[key] = [scrub_error(error)
+                                 for error in self._errors[key]]
+
+        return self._errors

--- a/ratechecker/tests/test_views_ratecheckerparameters.py
+++ b/ratechecker/tests/test_views_ratecheckerparameters.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from decimal import Decimal
 
 from ratechecker.models import Product
-from ratechecker.ratechecker_parameters import ParamsSerializer
+from ratechecker.ratechecker_parameters import ParamsSerializer, scrub_error
 
 
 class RateCheckerParametersTestCase(TestCase):
@@ -236,3 +236,10 @@ class RateCheckerParametersTestCase(TestCase):
         self.assertEqual(serializer.validated_data.get('min_ltv'), Decimal('90.1'))
         self.assertTrue(serializer.validated_data.get('min_ltv'), serializer.validated_data.get('max_ltv'))
         self.assertTrue(serializer.validated_data.get('ltv'), serializer.validated_data.get('max_ltv'))
+
+    def test_error_scrubber(self):
+        bad_value1 = 'CONFFQ684<SCRIPT>ALERT(1)</SCRIPT>'
+        bad_value2 = r'%3Cscript%3CEalert(1)%3C%2fscript%3E'
+        for char in ['<', '>', r'%3C', r'%3E']:
+            self.assertNotIn(char, scrub_error(bad_value1))
+            self.assertNotIn(char, scrub_error(bad_value2))


### PR DESCRIPTION
This makes sure no script tags can be included in api error messages.

An api error message on a rejected value could include a script tag:

<img width="578" alt="api_error_with_script" src="https://cloud.githubusercontent.com/assets/515885/20816278/87de2b7a-b7ef-11e6-9684-87cff093eb23.png">

Rather than hack the DRF error framework, this defangs any returned error messages:

<img width="531" alt="api_error_defanged" src="https://cloud.githubusercontent.com/assets/515885/20816297/a4c79ed8-b7ef-11e6-9a74-9662675db058.png">

## Review
@cfpb/cfgov-backends 
@lfatty
