### PR TITLE
Enforce non-zero price in ratechecker API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
+- Enforce non-zero price in ratechecker API.
 
 ## 0.9.94 - 2017-02-02
 - Add a monitor to watch for changes in census county values

--- a/ratechecker/ratechecker_parameters.py
+++ b/ratechecker/ratechecker_parameters.py
@@ -106,10 +106,14 @@ class ParamsSerializer(serializers.Serializer):
 
     def validate_price(self, value):
         """
-        Validate price and convert to positive if negative
+        Validate price, convert to positive if negative, and enforce a
+        minimum value of 0.
         """
         if value < 0:
             value = abs(value)
+        elif value == 0:
+            value = Decimal('1')
+
         return value
 
     def validate_lock(self, value):

--- a/ratechecker/tests/test_views_ratecheckerparameters.py
+++ b/ratechecker/tests/test_views_ratecheckerparameters.py
@@ -160,11 +160,23 @@ class RateCheckerParametersTestCase(TestCase):
         self.assertTrue(serializer.is_valid())
         self.assertEqual(serializer.validated_data.get('loan_amount'), Decimal('10000'))
 
+    def test_is_valid__price(self):
+        self.data['price'] = 1000
+        serializer = ParamsSerializer(data=self.data)
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data['price'], Decimal('1000'))
+
     def test_is_valid__price_negative(self):
         self.data['price'] = -10000
         serializer = ParamsSerializer(data=self.data)
         self.assertTrue(serializer.is_valid())
         self.assertEqual(serializer.validated_data.get('price'), Decimal('10000'))
+
+    def test_is_valid__price_zero(self):
+        self.data['price'] = 0
+        serializer = ParamsSerializer(data=self.data)
+        self.assertTrue(serializer.is_valid())
+        self.assertEqual(serializer.validated_data['price'], Decimal('1'))
 
     def test_is_valid__state_invalid(self):
         self.data['state'] = 123


### PR DESCRIPTION
Passing a 'price' parameter of 0 causes a `DivisionByZero` exception. This change modifies the API to change `price=0` to `price=1`. This solely prevents this case in the API and has no effect on the application frontend which already enforces a minimum price.

We've been a fair number of 500 errors like this recently.

<details>
<summary>Here's an example stack trace</summary>

```
Internal Server Error: /oah-api/rates/rate-checker Traceback (most recent call last):
...
  File "/srv/cfgov/current/venv/lib/python2.7/site-packages/ratechecker/views.py", line 171, in rate_checker
    if serializer.is_valid():
  File "/srv/cfgov/current/venv/lib/python2.7/site-packages/rest_framework/serializers.py", line 191, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
  File "/srv/cfgov/current/venv/lib/python2.7/site-packages/rest_framework/serializers.py", line 374, in run_validation
    value = self.validate(value)
  File "/srv/cfgov/current/venv/lib/python2.7/site-packages/ratechecker/ratechecker_parameters.py", line 90, in validate
    "%f" % (attrs['loan_amount'] / attrs['price'] * 100)
  File "/opt/rh/python27/root/usr/lib64/python2.7/decimal.py", line 1323, in __truediv__
    return context._raise_error(DivisionByZero, 'x / 0', sign)
  File "/opt/rh/python27/root/usr/lib64/python2.7/decimal.py", line 3872, in _raise_error
    raise error(explanation)
DivisionByZero: x / 0
```
</details>