### PR TITLE
Add new API endpoint to get ratechecker data load timestamp 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ All notable changes to this project will be documented in this file.
 We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
+- Add new ratechecker API endpoint to check data load timestamp.
 
 ## 0.9.94 - 2017-02-02
 - Add a monitor to watch for changes in census county values

--- a/ratechecker/urls.py
+++ b/ratechecker/urls.py
@@ -1,10 +1,15 @@
 from django.conf.urls import url
 
-from ratechecker.views import rate_checker, rate_checker_fees
+from ratechecker.views import (
+    RateCheckerStatus, rate_checker, rate_checker_fees
+)
+
 
 urlpatterns = [
     url(r'rate-checker$',
         rate_checker, name='rate-checker'),
+    url(r'rate-checker/status$',
+        RateCheckerStatus.as_view(), name='rate-checker-status'),
     url(r'rate-checker-fees$',
         rate_checker_fees, name='rate-checker-fees'),
 ]

--- a/ratechecker/views.py
+++ b/ratechecker/views.py
@@ -3,6 +3,7 @@ from django.db.models import Q, Sum, Avg
 from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from ratechecker.models import Region, Rate, Adjustment, Fee
 from ratechecker.ratechecker_parameters import ParamsSerializer
@@ -201,3 +202,13 @@ def rate_checker_fees(request):
             return Response(
                 serializer.errors, status=status.HTTP_400_BAD_REQUEST
             )
+
+
+class RateCheckerStatus(APIView):
+    def get(self, request, format=None):
+        try:
+            load_ts = Region.objects.latest('data_timestamp').data_timestamp
+        except Region.DoesNotExist:
+            load_ts = None
+
+        return Response({'load': load_ts})

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -2,4 +2,5 @@
 
 coverage==4.2
 mock==2.0.0
+model_mommy==1.2.6
 csvkit==0.9.1


### PR DESCRIPTION
## Overview

This commit adds a new ratechecker API endpoint at `/rate-checker/status` that returns a JSON blob with a `"load"` key containing the timestamp of the most recent data load, e.g.

```sh
$ curl -H "Accepts: application/json" http://localhost:8000/oah-api/rates/rate-checker/status
{"load":"2017-02-14T05:00:00Z"}
```

If no data exists, it returns

```sh
$ curl -H "Accepts: application/json" http://localhost:8000/oah-api/rates/rate-checker/status
{"load":null}
```

This new endpoint uses Django Rest Framework so has the nice browseable UI when accessed via a browser:

![image](https://cloud.githubusercontent.com/assets/654645/24006892/5964ce1a-0a43-11e7-8d9f-63d9d7e3adf9.png)

This will be useful for external services checking the recency of available data.

## Testing

To run unit tests within this repo (make sure you `pip install -r requirements/test.txt`):

```sh
(owning-a-home-api) $ ./pytest.sh
................................................................................................
----------------------------------------------------------------------
Ran 96 tests in 8.117s
OK
```

To run ratechecker unit tests within cfgov-refresh:

```sh
(cfgov-refresh) $ pip install git+https://github.com/cfpb/owning-a-home-api.git@ratechecker-api-status#egg=owning-a-home-api
(cfgov-refresh) $ PYTHONPATH=. DJANGO_SETTINGS_MODULE=cfgov.settings.test_nomigrations python cfgov/manage.py test ratechecker.tests
.........................................................
----------------------------------------------------------------------
Ran 70 tests in 2.950s
OK
```

With a production data dump, run a local server and visit [http://localhost:8000/oah-api/rates/rate-checker/status](http://localhost:8000/oah-api/rates/rate-checker/status).