### PR TITLE
Add 'raise_for_status' to capture status errors for troubleshooting

### DIFF
--- a/countylimits/data_collection/county_data_monitor.py
+++ b/countylimits/data_collection/county_data_monitor.py
@@ -14,6 +14,7 @@ CHANGELOG_ID = 'tab_2010'
 
 def get_current_log():
     changelog_response = requests.get(CENSUS_CHANGELOG)
+    changelog_response.raise_for_status()
     soup = bs(changelog_response.text, 'lxml')
     return soup.find("div", {"id": CHANGELOG_ID}).text
 


### PR DESCRIPTION
This script encountered a request that returned a 403 "Forbidden" status code, but continued on, eventually throwing an unhelpful parsing error.

This will raise a more understandable error before unleashing beautifulsoup, if we encounter such a problem again.

cc @acrewdson