### PR TITLE
Convert manage command to argparse syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
 
 ## Unreleased
 
+## 0.10.3 - 2017-12-20
+- Updated county-limit data
+- Removed initial_data fixture
+- Allow loading limits from fixture or CSV
+
 ## 0.9.96 - 2017-04-28
 - Load validation scenarios from external file instead of Python module.
 - Ratechecker loader refactor.


### PR DESCRIPTION
The load_county_limits management command was written when Django used
optparse for handling command arguments. This switches to the preferred
argparse syntax for handling args and options.