### PR TITLE
test if cleanup gets rid of old egg info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ after_success:
 - coveralls
 deploy:
   provider: releases
-  skip_cleanup: true
+  skip_cleanup: false
   api_key:
     secure: JSajnwpeUixOaWnQzaQCmeg9/74h/QKFtz7difgKuUg7SmuY462Jyr2mkTQkYQWPR28lqB/pIp7DlTjrN9inxpdtVpsm0RSgvuzvW7ZmlWr2xLb6wjHMArtRVJsdqODauQa9EH2ArqeKvXrCqWP2LQI6RFgoElOH3ilcemElj+w=
   file_glob: true


### PR DESCRIPTION
In trying to understand why Travis attaches a wheel to this repo with '.dev0+sha' in the name we noticed that this form first makes it appearance [here](https://travis-ci.org/cfpb/owning-a-home-api#L735-L736) in the Travis build.

This PR tests whether setting the Travis config to `skip_cleanup: false` gets rid of this egg reference.

