### PR TITLE
Support optional testing of other databases

### DIFF
--- a/docs/mysql.md
+++ b/docs/mysql.md
@@ -1,6 +1,8 @@
 # Using MySQL
 
-For testing, the default Django sqlite database will be set up for you automatically. If you want to load a MySQL dataset, you can edit `settings_for_testing.py` to uncomment the MySQL database section and install MySQL as follows:
+For testing, the default Django sqlite database will be set up for you automatically. If you want to load a MySQL dataset, you can install MySQL as follows and run tests by specifying a DATABASE_URL like so: `DATABASE_URL=mysql://user:password@localhost/db ./pytest.sh`
+
+Installing MySQL:
 ```shell
 pip install requirements/mysql.txt
 brew install mysql

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,5 +1,6 @@
 -r base.txt
 
 coverage==4.2
+dj-database-url==0.4.2
 mock==2.0.0
 model_mommy==1.2.6

--- a/settings_for_testing.py
+++ b/settings_for_testing.py
@@ -1,6 +1,8 @@
 import os
 import sys
 
+import dj_database_url
+
 BASE_DIR = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(os.path.abspath(os.path.join(BASE_DIR, '..')))
 
@@ -41,16 +43,9 @@ DATABASES = {
     }
 }
 
-# '''if using MySQL and a cfgov-refresh production data load:'''
+if 'DATABASE_URL' in os.environ:
+    DATABASES['default'] = dj_database_url.config()
 
-# DATABASES = {
-#     'default': {
-#            'ENGINE': 'django.db.backends.mysql',
-#            'NAME': 'v1',
-#            'USER': 'root',
-#            'PASSWORD': '',
-#     }
-# }
 
 LANGUAGE_CODE = 'en-us'
 TIME_ZONE = 'UTC'


### PR DESCRIPTION
This change adds support for using the `DATABASE_URL` environment variable to specify Django's test database, based on the [dj-database-url](https://github.com/kennethreitz/dj-database-url) package.

It lets you run tests against e.g. Postgres:

```sh
$ DATABASE_URL=postgres://user@localhost/db ./pytest.sh
```

(Note that this will require first creating a local database and `pip install`ing `psycopg2==2.7.3.2`.)

It adds `dj-database-url==0.4.2` to the test requirements as that matches the current version in cfgov-refresh.

## Notes

- @chosak  and I paired on this. This is part of the work being done on platform#2567 to add Postgres compatibility to all cf.gov code. We're hoping to use this pattern with all satellite apps to make database testing easier everywhere.

## Checklist

* [X] Changes are limited to a single goal (no scope creep)
* [X] Code can be automatically merged (no conflicts)
* [X] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [X] Passes all existing automated tests
* [X] New functions include new tests
* [X] New functions are documented (with a description, list of inputs, and expected output)
* [X] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
