### PR TITLE
Move dj-database-url requirement to base

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 beautifulsoup4==4.5.3
 Django==1.8.15
 django-cors-headers
+dj-database-url==0.4.2
 django-localflavor
 djangorestframework==3.1.3
 lxml==3.7.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,6 +1,5 @@
 -r base.txt
 
 coverage==4.2
-dj-database-url==0.4.2
 mock==2.0.0
 model_mommy==1.2.6


### PR DESCRIPTION
This change only affects this repo, but will keep Jenkins jobs from
hitting import failures.

The Jenkins jobs install base requirements and then issue manage.py
commands, but the repo's manage.py file uses settings_for_testing.py.

Since the requirements files only affect this repo, it's most efficient
to move the db requirement into base.txt and leave the jenkins jobs
alone.