### PR TITLE
Remove Django 1.8 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,62 +1,13 @@
-All notable changes to this project will be documented in this file.
-We follow the [Semantic Versioning 2.0.0](http://semver.org/) format.
+This project no longer uses `CHANGELOG.md` to track release changes.
 
-## Unreleased
+See the project repository release history at:
 
-## 0.10.3 - 2017-12-20
-- Updated county-limit data
-- Removed initial_data fixture
-- Allow loading limits from fixture or CSV
+https://github.com/cfpb/owning-a-home-api/releases
 
-## 0.9.96 - 2017-04-28
-- Load validation scenarios from external file instead of Python module.
-- Ratechecker loader refactor.
+To see the legacy version of this file, visit:
 
-## 0.9.95 - 2017-03-17
-- Enforce non-zero price in ratechecker API.
-- Add new ratechecker API endpoint to check data load timestamp.
-- Fixes unit tests so they can run after "pip install".
+https://github.com/cfpb/owning-a-home-api/blob/0.11.1/CHANGELOG.md
 
-## 0.9.94 - 2017-02-02
-- Add a monitor to watch for changes in census county values
-- Adds automated county mortgage limit collection script and command
-- Loses the "v" in the release number
+or, from the command line:
 
-## 0.9.93 - 2017-01-25
-- Remove unused `mortgageinsurance` app.
-- Add a monitor to watch for census county changes.
-- `load_daily_data` optional `--database` argument.
-- Bring ratechecker data load job code up to date.
-
-## 0.9.92 - 2016-12-31
-- 2017 update for county-level mortgage-limit data 
-
-## 0.9.91 - 2016-12-02
-- API security update for error responses
-
-## 0.9.9 - 2016-10-27
-- Updated djangorestframework from 2.4.3 to 3.1.3
-- Bumped Django requirements to 1.8.15 to match cfgov site
-- Added a whitelist check for the countylimit API's `state` querystring parameter
-
-## 0.9.6 - 2015-01-09
-- continue loading data even if some scenarios do not match
-
-## 0.9.5 - 2015-01-07
-- add 2015 county limits data file
-- fix Travis CI testing
-
-## 0.9.3 - 2015-01-07
-- stop ignoring scenarios with FHA-HB loans during data load
-
-## 0.9.2 - 2015-01-06
-- use .5 limit in both API results and testing of data loads
-
-## 0.9.1 - 2015-01-05
-- alpha version of the tool
-
-
-## 0.0.1 - 2014-11-07
-
-### Added
-- Initial state.
+`git show 0.11.1:CHANGELOG.md`

--- a/setup.py
+++ b/setup.py
@@ -14,11 +14,11 @@ def read_file(filename):
 
 install_requires = [
     'beautifulsoup4>=4.5.0,<4.7',
-    'Django>=1.8,<1.12',
+    'Django>=1.11,<1.12',
     'django-cors-headers',
     'dj-database-url>=0.4.2,<1',
     'django-localflavor',
-    'djangorestframework==3.6.4',  # Latest version that supports both Django 1.8 and 1.11
+    'djangorestframework>=3.6,<3.9',
     'requests>=2.18,<3',
     'unicodecsv==0.14.1',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=dj{18,111}
+envlist=dj{111}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -10,5 +10,4 @@ commands=
     coverage report --skip-covered
 
 deps=
-    dj18: Django>=1.8,<1.9
     dj111: Django>=1.11,<1.12


### PR DESCRIPTION
- Remove Django 1.8 support from `setup.py` and `tox.ini`
- Allow flexible version of djangorestframework - any version that supports Django 1.11