### PR TITLE
Prevent IndexError when building date stamp

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -16,7 +16,7 @@ This app exposes two API endpoints, `/oah-api/rates/rate-checker` and
 | loan_term | The loan term (years) | Yes | N/A | 30, 15 |
 | loan_type | The type of loan | Yes | N/A | JUMBO = Jumbo Loan,<br>CONF = Conventional Loan,<br>AGENCY = Agency Loan,<br>FHA = Federal Housing Administration Loan,<br>VA = Veteran Affairs Loan,<br>VA-HB = Veteran Affairs High Balance Loan,<br>FHA-HB = Federal Housing Administration High Balance Loan |
 | lock | Rate lock period | No | 60 | Typically, 30, 45, or 60.<br>One lender in the database has non-standard rate lock periods, so the code converts a single number to a range: <= 30; >30 and <=45; >45 and <= 60 respectively |
-| ltv [*1](#1) | Loan to value | No | N/A | Calculated by dividing the loan amount by the house price |
+| ltv [`*1](#1)` | Loan to value | No | N/A | Calculated by dividing the loan amount by the house price |
 | maxfico | The maximum FICO score | Yes | N/A | 0 - 850.<br>In practice, <600 will return no results.  For optimal functioning, MinFICO and MaxFICO should be coordinated.  Either, they should be the same value, thereby providing a point estimate of the FICO score, or they should be configured to provide a 20-point range, eg, 700-719.  Ranges should be specified to start on an even 20 multiple and end on a 19, 39, 59, etc., except for the top bucket which is 840-850. |
 | minfico | The minimum FICO score | Yes | N/A | 0 - 850,<br>see maxfico for more info. |
 | points | Points | No | 0 | This number is used as the centroid of a range, +/- 0.5, to constrain the results. Input could be any decimal roughly within -4 to +4, but in practice anything outside of -2 to +3 is likely to have few results. |
@@ -25,10 +25,12 @@ This app exposes two API endpoints, `/oah-api/rates/rate-checker` and
 | rate_structure | The rate structure of the loan | Yes | N/A | FIXED = Fixed Rate,<br>ARM = Adjusted Rate Mortgage |
 | state | The US state | Yes | N/A | _all the US state's abbreviations_ |
 
-*1: We actually calculate its value and don't check the value sent in request
+`*`1: We actually calculate its value and don't check the value sent in request
 
-ratechecker will return a JSON object containing `data` and `timestamp`, it will also contain
-`fees` field when requesting `/oah-api/rates/rate-checker-fees`.
+The ratechecker will return a JSON object containing `data` and `timestamp`. It will also contain
+a `fees` field when requesting `/oah-api/rates/rate-checker-fees`.
+
+The `timestamp` will be `null` if a timestamp can't be found, which could happen if a request is made just as tables are being updated.
 
 ratechecker has a management command, `load_daily_data`, which loads daily interest rate data from CSV.
 

--- a/ratechecker/dataset.py
+++ b/ratechecker/dataset.py
@@ -39,7 +39,8 @@ class Dataset(object):
         return self.cover_sheet.date.strftime('%Y%m%d')
 
     def load(self):
-        for key, loader_cls in self.loaders.items():
+        # Sort the list of loaders so that Region loads last, as a bellwether
+        for key, loader_cls in sorted(self.loaders.items()):
             try:
                 f = self.datafile(key)
             except KeyError:

--- a/ratechecker/tests/test_views_rate_query.py
+++ b/ratechecker/tests/test_views_rate_query.py
@@ -146,8 +146,7 @@ class RateQueryTestCase(TestCase):
         self.initialize_params({'state': 'IL'})
         result = get_rates(self.params.__dict__, return_fees=True)
         self.assertFalse(result['data'])
-        self.assertTrue(result['timestamp'])
-        self.assertEqual(result['timestamp'].date(), self.NOW.date())
+        self.assertFalse(result['timestamp'])
         self.assertFalse('fees' in result)
 
     def test_get_rates__rate_structure(self):

--- a/ratechecker/views.py
+++ b/ratechecker/views.py
@@ -20,6 +20,8 @@ def get_rates(params_data, data_load_testing=False, return_fees=False):
 
     region_ids = list(Region.objects.filter(
         state_id=params_data.get('state')).values_list('region_id', flat=True))
+    if not region_ids:
+        return {'data': {}, 'timestamp': None}
 
     rates = Rate.objects.filter(
         region_id__in=region_ids,

--- a/ratechecker/views.py
+++ b/ratechecker/views.py
@@ -54,18 +54,28 @@ def get_rates(params_data, data_load_testing=False, return_fees=False):
     products = {}
     for rate in rates:
         all_rates.append(rate)
-        products["{}{}".format(rate.product_id, rate.region_id)] = rate.product_id
+        products["{}{}".format(
+            rate.product_id, rate.region_id)] = rate.product_id
     product_ids = products.values()
 
-    adjustments = Adjustment.objects.filter(product__plan_id__in=product_ids).filter(
-        Q(max_loan_amt__gte=params_data.get('loan_amount')) | Q(max_loan_amt__isnull=True),
-        Q(min_loan_amt__lte=params_data.get('loan_amount')) | Q(min_loan_amt__isnull=True),
-        Q(prop_type=params_data.get('property_type')) | Q(prop_type__isnull=True) | Q(prop_type=""),
-        Q(state=params_data.get('state')) | Q(state__isnull=True) | Q(state=""),
-        Q(max_fico__gte=params_data.get('maxfico')) | Q(max_fico__isnull=True),
-        Q(min_fico__lte=params_data.get('minfico')) | Q(min_fico__isnull=True),
-        Q(min_ltv__lte=params_data.get('min_ltv')) | Q(min_ltv__isnull=True),
-        Q(max_ltv__gte=params_data.get('max_ltv')) | Q(max_ltv__isnull=True),
+    adjustments = Adjustment.objects.filter(
+        product__plan_id__in=product_ids).filter(
+        Q(max_loan_amt__gte=params_data.get('loan_amount'))
+            | Q(max_loan_amt__isnull=True),
+        Q(min_loan_amt__lte=params_data.get('loan_amount'))
+            | Q(min_loan_amt__isnull=True),
+        Q(prop_type=params_data.get('property_type'))
+            | Q(prop_type__isnull=True) | Q(prop_type=""),
+        Q(state=params_data.get('state'))
+            | Q(state__isnull=True) | Q(state=""),
+        Q(max_fico__gte=params_data.get('maxfico'))
+            | Q(max_fico__isnull=True),
+        Q(min_fico__lte=params_data.get('minfico'))
+            | Q(min_fico__isnull=True),
+        Q(min_ltv__lte=params_data.get('min_ltv'))
+            | Q(min_ltv__isnull=True),
+        Q(max_ltv__gte=params_data.get('max_ltv'))
+            | Q(max_ltv__isnull=True),
     ).values('product_id',
              'affect_rate_type').annotate(sum_of_adjvalue=Sum('adj_value'))
 
@@ -91,7 +101,7 @@ def get_rates(params_data, data_load_testing=False, return_fees=False):
             current_difference = abs(
                 params_data.get('points') -
                 available_rates[rate.product_id].total_points
-                )
+            )
             new_difference = abs(params_data.get('points') - rate.total_points)
             if new_difference < current_difference or (
                     new_difference == current_difference and
@@ -129,8 +139,9 @@ def get_rates(params_data, data_load_testing=False, return_fees=False):
         results['fees'] = averages
 
     if not data:
-        obj = Region.objects.all()[0]
-        results['timestamp'] = obj.data_timestamp
+        obj = Region.objects.first()
+        if obj:
+            results['timestamp'] = obj.data_timestamp
 
     return results
 


### PR DESCRIPTION
The rate checker acquires its date stamp from the first entry in the region table.
If a request occurred while the table was being refreshed, the view would find no first entry and
raise an IndexError, causing a server error.

This allows the view to complete without a date stamp during the brief time regions are not available.

PR includes some pep8 fixes.