### PR TITLE
Add Python 3 support to this repository 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 - pip install coveralls
 script:
 - tox
-- python2.7 setup.py bdist_wheel
+- python2.7 setup.py sdist bdist_wheel --universal
 after_success:
 - coveralls
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 language: python
 python:
-- 2.7.14
+- 2.7
+- 3.6
 install:
-- pip install tox
-- pip install coveralls
+- pip install tox-travis
 script:
 - tox
-- python2.7 setup.py sdist bdist_wheel --universal
+- python2.7 setup.py bdist_wheel --universal
 after_success:
 - coveralls
 deploy:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The tool is intended to be a module that runs inside a Django project, but it ca
 These instructions are for installation on a Mac with OS X Yosemite (version 10.10.x), but they could be adapted for other environments.
 
 **Dependencies**
-* [Python 2.7](https://www.python.org/download/releases/2.7/)
+* [Python 2.7 or 3.6](https://www.python.org/)
 * [pip](https://pypi.python.org/pypi/pip)
 * [virtualenv](https://virtualenv.pypa.io/en/latest/)
 * [Django](https://docs.djangoproject.com/en/1.11/)
@@ -45,7 +45,7 @@ pip install -e '.[testing]'
 
 ```shell
 ./manage.py migrate --noinput
-./manage.py loaddata countylimit_data.json
+./manage.py loaddata countylimits/fixtures/countylimit_data.json
 ./manage.py load_daily_data ratechecker/data/sample.zip
 ./manage.py runserver
 ```

--- a/countylimits/data_collection/county_data_monitor.py
+++ b/countylimits/data_collection/county_data_monitor.py
@@ -18,14 +18,16 @@ def get_current_log():
     return soup.find("div", {"id": CHANGELOG_ID}).text
 
 
-def get_base_log():
-    with open(LAST_CHANGELOG, 'r') as f:
+def get_base_log(from_filename=None):
+    filename = from_filename or LAST_CHANGELOG
+    with open(filename, 'r') as f:
         base_log = f.read()
         return base_log
 
 
-def store_change_log(newlog):
-    with open(LAST_CHANGELOG, 'w') as f:
+def store_change_log(newlog, to_filename=None):
+    filename = to_filename or LAST_CHANGELOG
+    with open(filename, 'w') as f:
         f.write(newlog)
 
 

--- a/countylimits/data_collection/gather_county_data.py
+++ b/countylimits/data_collection/gather_county_data.py
@@ -75,7 +75,7 @@ def download_datafile(url):
 
 
 def dump_to_csv(filepath, headings, data):
-    with open(filepath, 'w') as f:
+    with open(filepath, 'wb') as f:
         fieldnames = [key for key in headings]
         writer = Writer(f)
         writer.writerow(fieldnames)

--- a/countylimits/data_collection/gather_county_data.py
+++ b/countylimits/data_collection/gather_county_data.py
@@ -3,8 +3,16 @@ import os
 from collections import OrderedDict
 
 import requests
-from unicodecsv import DictReader
-from unicodecsv import writer as Writer
+import six
+
+
+if six.PY2:  # pragma: no cover
+    from unicodecsv import DictReader
+    from unicodecsv import writer as Writer
+else:  # pragma: no cover
+    from csv import DictReader
+    from csv import writer as Writer
+
 
 ERROR_MSG = "Script failed to process all files."
 API_DIR = os.path.abspath(
@@ -75,7 +83,7 @@ def download_datafile(url):
 
 
 def dump_to_csv(filepath, headings, data):
-    with open(filepath, 'wb') as f:
+    with open(filepath, 'w') as f:
         fieldnames = [key for key in headings]
         writer = Writer(f)
         writer.writerow(fieldnames)

--- a/countylimits/management/commands/load_county_limits.py
+++ b/countylimits/management/commands/load_county_limits.py
@@ -10,10 +10,14 @@ DEFAULT_COUNTYLIMIT_FIXTURE = 'countylimit_data.json'
 DEFAULT_CSV = {'latest': 'countylimits/data/county_limit_data_latest.csv'}
 
 
-def dump_countylimit_fixture():
+def dump_countylimit_fixture(to_filename=None):
+    filename = (
+        to_filename or
+        'countylimits/fixtures/{}'.format(DEFAULT_COUNTYLIMIT_FIXTURE)
+    )
+
     sysout = sys.stdout
-    with open('countylimits/fixtures/{}'.format(
-            DEFAULT_COUNTYLIMIT_FIXTURE), 'w') as sys.stdout:
+    with open(filename, 'w') as sys.stdout:
         call_command('dumpdata', 'countylimits')
         sys.stdout = sysout
 

--- a/countylimits/models.py
+++ b/countylimits/models.py
@@ -1,6 +1,7 @@
 from django.db import models
 from localflavor.us.models import USStateField
 from localflavor.us.us_states import STATE_CHOICES
+from six import python_2_unicode_compatible, text_type
 
 
 abbr_to_name = dict(STATE_CHOICES)
@@ -13,6 +14,7 @@ http://en.wikipedia.org/wiki/FIPS_county_code
 """
 
 
+@python_2_unicode_compatible
 class State(models.Model):
     """ A basic State object. """
     state_fips = models.CharField(
@@ -22,10 +24,11 @@ class State(models.Model):
     class Meta:
         ordering = ['state_fips']
 
-    def __unicode__(self):
-        return u'%s' % abbr_to_name[self.state_abbr]
+    def __str__(self):
+        return '%s' % abbr_to_name[self.state_abbr]
 
 
+@python_2_unicode_compatible
 class County(models.Model):
     """ A basic state county object. """
     county_fips = models.CharField(
@@ -37,10 +40,11 @@ class County(models.Model):
     class Meta:
         ordering = ['county_fips']
 
-    def __unicode__(self):
-        return u'%s (%s)' % (self.county_name, self.county_fips)
+    def __str__(self):
+        return '%s (%s)' % (self.county_name, self.county_fips)
 
 
+@python_2_unicode_compatible
 class CountyLimit(models.Model):
     """ County limit object. """
     fha_limit = models.DecimalField(
@@ -60,8 +64,8 @@ class CountyLimit(models.Model):
                   'loan guaranty program limit')
     county = models.OneToOneField(County)
 
-    def __unicode__(self):
-        return u'CountyLimit %s' % self.id
+    def __str__(self):
+        return 'CountyLimit %s' % self.id
 
     @staticmethod
     def county_limits_by_state(state):
@@ -74,13 +78,13 @@ class CountyLimit(models.Model):
         limits = CountyLimit.objects.filter(county__state=state_obj)
         for countylimit in limits:
             data.append(
-                {u'state': unicode(abbr_to_name[state_obj.state_abbr]),
+                {u'state': text_type(abbr_to_name[state_obj.state_abbr]),
                  u'county': countylimit.county.county_name,
                  u'complete_fips': u'{}{}'.format(
                      state_obj.state_fips,
                      countylimit.county.county_fips),
-                 u'gse_limit': unicode(countylimit.gse_limit),
-                 u'fha_limit': unicode(countylimit.fha_limit),
-                 u'va_limit': unicode(countylimit.va_limit)}
+                 u'gse_limit': text_type(countylimit.gse_limit),
+                 u'fha_limit': text_type(countylimit.fha_limit),
+                 u'va_limit': text_type(countylimit.va_limit)}
             )
         return data

--- a/countylimits/tests.py
+++ b/countylimits/tests.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from decimal import Decimal
 import json
 import os
@@ -37,14 +39,13 @@ BASE_PATH = os.path.dirname(os.path.abspath(__file__)) + '/'
 class DataAutomationTests(unittest.TestCase):
 
     def setUp(self):
-        #stdout_patch = mock.patch('sys.stdout')
-        #stdout_patch.start()
-        #self.addCleanup(stdout_patch.stop)
-        pass
+        stdout_patch = mock.patch('sys.stdout')
+        stdout_patch.start()
+        self.addCleanup(stdout_patch.stop)
 
     def test_translate_data(self):
-        test_list = [u'9999900000NON-METRO                                         203B S02070000275665035295004266250530150AK050ALASKA                    BETHEL CENSUS A201611292017010102080002015    ']  # noqa
-        expected_dict = {'county-fips': u'050', 'limit-1-unit': u'0275665', 'limit-2-units': u'0352950', 'county-transaction-date': u'20161129', 'metro-name': u'NON-METRO', 'metro-code': u'00000', 'year-for-median-determining-limit': u'2015', 'median-price-determining-limit': u'0208000', 'county-name': u'BETHEL CENSUS A', 'state': u'AK', 'program': u'203B', 'limit-type': u'S', 'median-price': u'0207000', 'limit-4-units': u'0530150', 'limit-transaction-date': u'20170101', 'msa-code': u'99999', 'limit-3-units': u'0426625', 'state-name': u'ALASKA'}  # noqa
+        test_list = ['9999900000NON-METRO                                         203B S02070000275665035295004266250530150AK050ALASKA                    BETHEL CENSUS A201611292017010102080002015    ']  # noqa
+        expected_dict = {'county-fips': '050', 'limit-1-unit': '0275665', 'limit-2-units': '0352950', 'county-transaction-date': '20161129', 'metro-name': 'NON-METRO', 'metro-code': '00000', 'year-for-median-determining-limit': '2015', 'median-price-determining-limit': '0208000', 'county-name': 'BETHEL CENSUS A', 'state': 'AK', 'program': '203B', 'limit-type': 'S', 'median-price': '0207000', 'limit-4-units': '0530150', 'limit-transaction-date': '20170101', 'msa-code': '99999', 'limit-3-units': '0426625', 'state-name': 'ALASKA'}  # noqa
         result = translate_data(test_list, CHUMS_MAP)[0]
         for key in ['county-fips', 'metro-name', 'county-name', 'state']:
             self.assertEqual(result[key], expected_dict[key])

--- a/ratechecker/dataset.py
+++ b/ratechecker/dataset.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
+import io
+
 from collections import OrderedDict
 from datetime import datetime, time
 from django.utils import timezone
@@ -50,7 +52,11 @@ class Dataset(object):
                 if key == 'fee':
                     continue
                 raise
-            loader = loader_cls(f, data_timestamp=self.timestamp)
+
+            # The zip file may be opened as binary, but we want to process the
+            # files that it contains as text.
+            f_text = io.TextIOWrapper(f)
+            loader = loader_cls(f_text, data_timestamp=self.timestamp)
             loader.load()
 
     def datafile(self, name):

--- a/ratechecker/management/commands/load_daily_data.py
+++ b/ratechecker/management/commands/load_daily_data.py
@@ -16,7 +16,7 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument(
-            'archive_filename', type=argparse.FileType('r'),
+            'archive_filename', type=argparse.FileType('rb'),
             help='Archive containing interest rate data'
         )
         parser.add_argument(

--- a/ratechecker/tests/helpers.py
+++ b/ratechecker/tests/helpers.py
@@ -1,4 +1,4 @@
-from cStringIO import StringIO
+from six import BytesIO
 from datetime import date
 from zipfile import ZipFile
 
@@ -27,7 +27,7 @@ def get_sample_cover_sheet(day=None):
 def get_sample_dataset_zipfile(day=None, datasets={}):
     day = day or date.today()
 
-    f = StringIO()
+    f = BytesIO()
     zf = ZipFile(f, 'w')
     zf.writestr('CoverSheet.xml', get_sample_cover_sheet(day=day))
 

--- a/ratechecker/tests/test_dataset.py
+++ b/ratechecker/tests/test_dataset.py
@@ -39,6 +39,38 @@ class TestDataset(TestCase):
 
         loader.load.assert_called_once()
 
+    def test_load_fails_if_dataset_missing(self):
+        dataset = get_sample_dataset(
+            day=date(2017, 4, 3),
+            datasets={
+                '20170403_key.txt': 'testing',
+            }
+        )
+
+        loader = Mock()
+        loader.return_value = loader
+        dataset.loaders = {'other_key': loader}
+
+        with self.assertRaises(KeyError):
+            dataset.load()
+
+    def test_load_succeeds_even_if_fee_dataset_missing(self):
+        dataset = get_sample_dataset(
+            day=date(2017, 4, 3),
+            datasets={
+                '20170403_key.txt': 'testing',
+            }
+        )
+
+        loader = Mock()
+        loader.return_value = loader
+        dataset.loaders = {'fee': loader}
+
+        try:
+            dataset.load()
+        except KeyError:  # pragma: no cover
+            self.fail('load should fail even if fee data is missing')
+
     def test_datafile(self):
         dataset = get_sample_dataset(
             day=date(2017, 4, 3),

--- a/ratechecker/tests/test_dataset.py
+++ b/ratechecker/tests/test_dataset.py
@@ -80,7 +80,7 @@ class TestDataset(TestCase):
         )
 
         f = dataset.datafile('something')
-        self.assertEqual(f.read(), 'testing')
+        self.assertEqual(f.read(), b'testing')
 
 
 class TestCoverSheet(TestCase):

--- a/ratechecker/tests/test_views.py
+++ b/ratechecker/tests/test_views.py
@@ -220,4 +220,4 @@ class RateCheckerStatusTest(APITestCase):
         timestamp = datetime(2017, 1, 2, 3, 4, 56, tzinfo=timezone.utc)
         mommy.make(Region, data_timestamp=timestamp)
         response = self.get()
-        self.assertIn('2017-01-02T03:04:56Z', response.content)
+        self.assertContains(response, '2017-01-02T03:04:56Z')

--- a/ratechecker/views.py
+++ b/ratechecker/views.py
@@ -176,9 +176,10 @@ def rate_checker(request):
 
         # Clean the parameters, make sure no leading or trailing spaces,
         # transform them to upper cases
-        fixed_data = dict(map(
-            lambda (k, v): (k, v.strip().upper()),
-            request.query_params.iteritems()))
+        fixed_data = {
+            k: v.strip().upper()
+            for k, v in request.query_params.items()
+        }
         fixed_data = set_lock_max_min(fixed_data)
         serializer = ParamsSerializer(data=fixed_data)
 
@@ -201,9 +202,10 @@ def rate_checker_fees(request):
     if request.method == 'GET':
         # Clean the parameters, make sure no leading or trailing spaces,
         # transform them to upper cases
-        fixed_data = dict(map(
-            lambda (k, v): (k, v.strip().upper()),
-            request.query_params.iteritems()))
+        fixed_data = {
+            k: v.strip().upper()
+            for k, v in request.query_params.items()
+        }
         serializer = ParamsSerializer(data=fixed_data)
 
         if serializer.is_valid():

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.6',,
+        'Programming Language :: Python :: 3.6',
         'Framework :: Django',
         'Development Status :: 5 - Production/Stable',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ install_requires = [
     'django-localflavor',
     'djangorestframework>=3.6,<3.9',
     'requests>=2.18,<3',
+    'six>=1.11.0,<2',
     'unicodecsv==0.14.1',
 ]
 
@@ -55,8 +56,9 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Intended Audience :: Developers',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 3.6',,
         'Framework :: Django',
         'Development Status :: 5 - Production/Stable',
         'Operating System :: OS Independent',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=dj{111}
+envlist=py{27,36}-dj{111}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -8,6 +8,10 @@ commands=
     coverage erase
     coverage run manage.py test {posargs}
     coverage report --skip-covered
+
+basepython=
+    py27: python2.7
+    py36: python3.6
 
 deps=
     dj111: Django>=1.11,<1.12


### PR DESCRIPTION
This PR adds (almost all that is needed for) Python 3 support for this project. The unit tests run via tox are now configured to test against both Python 2.7 and Python 3.6. The wheel built from releases of this project is now built as `--universal`.
 
Support for Python 2.6 has also been removed.
    
There's only one unit test left that fails, that relates to our use of [unicodecsv](https://pypi.org/project/unicodecsv/). Unfortunately this library doesn't seem to support Python 3.6, and [appears to be abandoned](https://github.com/jdunck/python-unicodecsv/pull/85#issuecomment-467981537).

I tried looking into this failure, but I thought it might be better to defer to @higs4281's experience here. Any idea what the proper incantation of `'rb'` or `'rU'` needs to be to make this work with Python 3?