### PR TITLE
Remove fees data loader and endpoint

### DIFF
--- a/ratechecker/README.md
+++ b/ratechecker/README.md
@@ -101,7 +101,7 @@ See the provided `data/sample.zip` file for an example minimal dataset.
 
 ## Validation
 
-Loaded data can be validatied against a set of predetermined scenarios that check the expected behavior of the rate search algorithm. The `CoverSheet.xml` file in the loaded dataset contains the expected API results; a [JSONL format](http://jsonlines.org/) file provided to the loader command contains the scenario definitions that should produce those results.
+Loaded data can be validated against a set of predetermined scenarios that check the expected behavior of the rate search algorithm. The `CoverSheet.xml` file in the loaded dataset contains the expected API results; a [JSONL format](http://jsonlines.org/) file provided to the loader command contains the scenario definitions that should produce those results.
 
 Each line in the scenario file (for example `ratechecker/data/sample-scenarios.jsonl`) contains the set of API parameters that define a single interest rate search, for example:
 

--- a/ratechecker/dataset.py
+++ b/ratechecker/dataset.py
@@ -10,14 +10,13 @@ import xml.etree.cElementTree as ET
 from zipfile import ZipFile
 
 from ratechecker.loader import (
-    AdjustmentLoader, FeeLoader, ProductLoader, RateLoader, RegionLoader
+    AdjustmentLoader, ProductLoader, RateLoader, RegionLoader
 )
 
 
 class Dataset(object):
     loaders = {
         'adjustment': AdjustmentLoader,
-        'fee': FeeLoader,
         'product': ProductLoader,
         'rate': RateLoader,
         'region': RegionLoader,

--- a/ratechecker/loader.py
+++ b/ratechecker/loader.py
@@ -44,7 +44,7 @@ class Loader(object):
         reader = csv.DictReader(self.f, delimiter=str(self.delimiter))
 
         for row in reader:
-            if row.has_key("ratesid"):
+            if 'ratesid' in row:
                 if row['ratesid'] not in entries:
                     yield self.make_instance(row)
                     entries.add(row['ratesid'])

--- a/ratechecker/loader.py
+++ b/ratechecker/loader.py
@@ -40,11 +40,18 @@ class Loader(object):
             raise LoaderError('no instances loaded')
 
     def generate_instances(self):
+        entries = set()
         reader = csv.DictReader(self.f, delimiter=str(self.delimiter))
 
         for row in reader:
-            yield self.make_instance(row)
-            self.count += 1
+            if row.has_key("ratesid"):
+                if row['ratesid'] not in entries:
+                    yield self.make_instance(row)
+                    entries.add(row['ratesid'])
+                    self.count += 1
+            else:
+                yield self.make_instance(row)
+                self.count += 1
 
     def make_instance(self, row):
         raise NotImplementedError('implemented in derived classes')

--- a/ratechecker/loader.py
+++ b/ratechecker/loader.py
@@ -5,7 +5,7 @@ import itertools
 
 from decimal import Decimal
 from django.utils import timezone
-from ratechecker.models import Adjustment, Fee, Product, Rate, Region
+from ratechecker.models import Adjustment, Product, Rate, Region
 
 
 class LoaderError(BaseException):
@@ -94,25 +94,6 @@ class AdjustmentLoader(Loader):
             min_ltv=self.nullable_decimal(row['minltv']),
             max_ltv=self.nullable_decimal(row['maxltv']),
             state=row['state'],
-            data_timestamp=self.data_timestamp
-        )
-
-
-class FeeLoader(Loader):
-    model_cls = Fee
-
-    def make_instance(self, row):
-        return self.model_cls(
-            plan_id=int(row['planid']),
-            product_id=int(row['prodid']),
-            state_id=row['stateid'],
-            lender=row['lender'],
-            single_family=bool(int(row['singlefamily'])),
-            condo=bool(int(row['condo'])),
-            coop=bool(int(row['coop'])),
-            origination_dollar=Decimal(row['originationdollar']),
-            origination_percent=Decimal(row['originationpercent']),
-            third_party=Decimal(row['thirdparty']),
             data_timestamp=self.data_timestamp
         )
 

--- a/ratechecker/migrations/0001_initial.py
+++ b/ratechecker/migrations/0001_initial.py
@@ -30,22 +30,6 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
-            name='Fee',
-            fields=[
-                ('fee_id', models.AutoField(serialize=False, primary_key=True)),
-                ('product_id', models.IntegerField()),
-                ('state_id', localflavor.us.models.USStateField(max_length=2)),
-                ('lender', models.CharField(max_length=16)),
-                ('single_family', models.BooleanField(default=True)),
-                ('condo', models.BooleanField(default=False)),
-                ('coop', models.BooleanField(default=False)),
-                ('origination_dollar', models.DecimalField(max_digits=8, decimal_places=2)),
-                ('origination_percent', models.DecimalField(max_digits=6, decimal_places=3)),
-                ('third_party', models.DecimalField(max_digits=8, decimal_places=2)),
-                ('data_timestamp', models.DateTimeField()),
-            ],
-        ),
-        migrations.CreateModel(
             name='Product',
             fields=[
                 ('plan_id', models.IntegerField(serialize=False, primary_key=True)),

--- a/ratechecker/migrations/0001_initial.py
+++ b/ratechecker/migrations/0001_initial.py
@@ -30,6 +30,22 @@ class Migration(migrations.Migration):
             ],
         ),
         migrations.CreateModel(
+            name='Fee',
+            fields=[
+                ('fee_id', models.AutoField(serialize=False, primary_key=True)),
+                ('product_id', models.IntegerField()),
+                ('state_id', localflavor.us.models.USStateField(max_length=2)),
+                ('lender', models.CharField(max_length=16)),
+                ('single_family', models.BooleanField(default=True)),
+                ('condo', models.BooleanField(default=False)),
+                ('coop', models.BooleanField(default=False)),
+                ('origination_dollar', models.DecimalField(max_digits=8, decimal_places=2)),
+                ('origination_percent', models.DecimalField(max_digits=6, decimal_places=3)),
+                ('third_party', models.DecimalField(max_digits=8, decimal_places=2)),
+                ('data_timestamp', models.DateTimeField()),
+            ],
+        ),
+        migrations.CreateModel(
             name='Product',
             fields=[
                 ('plan_id', models.IntegerField(serialize=False, primary_key=True)),

--- a/ratechecker/models.py
+++ b/ratechecker/models.py
@@ -139,22 +139,3 @@ class Rate(models.Model):
     base_rate = models.DecimalField(max_digits=6, decimal_places=3)
     total_points = models.DecimalField(max_digits=6, decimal_places=3)
     data_timestamp = models.DateTimeField()
-
-
-class Fee(models.Model):
-    fee_id = models.AutoField(primary_key=True)
-    plan = models.ForeignKey(Product)
-    product_id = models.IntegerField()
-    state_id = USStateField()
-    lender = models.CharField(max_length=16)
-    single_family = models.BooleanField(default=True)
-    condo = models.BooleanField(default=False)
-    coop = models.BooleanField(default=False)
-    origination_dollar = models.DecimalField(max_digits=8, decimal_places=2)
-    origination_percent = models.DecimalField(max_digits=6, decimal_places=3)
-    third_party = models.DecimalField(max_digits=8, decimal_places=2)
-    data_timestamp = models.DateTimeField()
-
-    class Meta:
-        unique_together = (("product_id", "state_id", "lender",
-                            "single_family", "condo", "coop"))

--- a/ratechecker/tests/management/commands/test_load_daily_data.py
+++ b/ratechecker/tests/management/commands/test_load_daily_data.py
@@ -58,7 +58,7 @@ class LoadDailyTestCase(TestCase):
             validation_filename,
             verbosity=0
         )
-        self.assertEqual(load.call_count, 5)
+        self.assertEqual(load.call_count, 4)
 
     @patch('ratechecker.loader.Loader.load', side_effect=RuntimeError)
     def test_run_command_calls_load_handles_load_exception(self, load):

--- a/ratechecker/tests/test_dataset.py
+++ b/ratechecker/tests/test_dataset.py
@@ -54,23 +54,6 @@ class TestDataset(TestCase):
         with self.assertRaises(KeyError):
             dataset.load()
 
-    def test_load_succeeds_even_if_fee_dataset_missing(self):
-        dataset = get_sample_dataset(
-            day=date(2017, 4, 3),
-            datasets={
-                '20170403_key.txt': 'testing',
-            }
-        )
-
-        loader = Mock()
-        loader.return_value = loader
-        dataset.loaders = {'fee': loader}
-
-        try:
-            dataset.load()
-        except KeyError:  # pragma: no cover
-            self.fail('load should fail even if fee data is missing')
-
     def test_datafile(self):
         dataset = get_sample_dataset(
             day=date(2017, 4, 3),

--- a/ratechecker/tests/test_loader.py
+++ b/ratechecker/tests/test_loader.py
@@ -8,7 +8,7 @@ from django.utils import timezone
 from model_mommy import mommy
 
 from ratechecker.loader import (
-    AdjustmentLoader, FeeLoader, Loader, LoaderError, ProductLoader,
+    AdjustmentLoader, Loader, LoaderError, ProductLoader,
     RateLoader, RegionLoader, split
 )
 from ratechecker.models import Product
@@ -218,59 +218,6 @@ class TestAdjustmentLoader(LoaderTestCaseMixin, TestCase):
 
     def test_state(self):
         self.assertEqual(self.load().state, 'NY')
-
-
-class TestFeeLoader(LoaderTestCaseMixin, TestCase):
-    loader_cls = FeeLoader
-
-    def setUp(self):
-        self.product = mommy.make(Product, plan_id=3)
-
-        self.row = {
-            'planid': str(self.product.plan_id),
-            'prodid': '2',
-            'stateid': 'NY',
-            'lender': 'FOOBAR',
-            'singlefamily': '0',
-            'condo': '0',
-            'coop': '1',
-            'originationdollar': '123',
-            'originationpercent': '90',
-            'thirdparty': '45',
-        }
-
-    def test_fee_id_autofield(self):
-        self.assertIsNone(self.load().fee_id)
-
-    def test_plan(self):
-        self.assertEqual(self.load().plan, self.product)
-
-    def test_product_id(self):
-        self.assertEqual(self.load().product_id, 2)
-
-    def test_state_id(self):
-        self.assertEqual(self.load().state_id, 'NY')
-
-    def test_lender(self):
-        self.assertEqual(self.load().lender, 'FOOBAR')
-
-    def test_single_family(self):
-        self.assertFalse(self.load().single_family)
-
-    def test_condo(self):
-        self.assertFalse(self.load().condo)
-
-    def test_coop(self):
-        self.assertTrue(self.load().coop)
-
-    def test_origination_dollar(self):
-        self.assertEqual(self.load().origination_dollar, Decimal(123))
-
-    def test_origination_percent(self):
-        self.assertEqual(self.load().origination_percent, Decimal(90))
-
-    def test_third_party(self):
-        self.assertEqual(self.load().third_party, Decimal(45))
 
 
 class TestProductLoader(LoaderTestCaseMixin, TestCase):

--- a/ratechecker/tests/test_views.py
+++ b/ratechecker/tests/test_views.py
@@ -9,7 +9,7 @@ from model_mommy import mommy
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from ratechecker.models import Region, Product, Rate, Adjustment, Fee
+from ratechecker.models import Region, Product, Rate, Adjustment
 from ratechecker.views import set_lock_max_min
 
 
@@ -58,14 +58,6 @@ class RateCheckerTestCase(APITestCase):
             [6, 33, 'R', '0.25', 100000, 500000, 'CONDO', 660, 780, 30, 95, 'DC'],
             [7, 77, 'P', '0.125', 100000, 500000, 'CONDO', 660, 780, 30, 95, 'VA'],
         ]
-        FEES = [
-            # plan_id, product_id, state_id, lender , single_family, condo, coop,
-            # origination_dollar, origination_percent, third_party
-            [11, 11111, 'DC', 'SMPL', 1, 1, 1, 1608.0000, .000, 587.2700],
-            [11, 11111, 'DC', 'SMPL1', 1, 0, 1, 1610.0000, .000, 589.2700],
-            [10, 11001, 'DC', 'SMPL1', 0, 1, 0, 1610.0000, .000, 589.2700],
-            [11, 11111, 'VA', 'SMPL2', 1, 1, 1, 1610.0000, .000, 589.2700],
-        ]
         NOW = timezone.now()
 
         for region in REGIONS:
@@ -98,15 +90,6 @@ class RateCheckerTestCase(APITestCase):
                 data_timestamp=NOW
             )
             adjustment.save()
-
-        for f in FEES:
-            fee = Fee(
-                plan_id=f[0], product_id=f[1], state_id=f[2], lender=f[3], single_family=f[4],
-                condo=f[5], coop=f[6], origination_dollar=Decimal("%s" % f[7]),
-                origination_percent=Decimal("%s" % f[8]), third_party=Decimal("%s" % f[9]),
-                data_timestamp=NOW
-            )
-            fee.save()
 
     def test_set_lock_max_min(self):
         """Make sure max and min are set"""

--- a/ratechecker/tests/test_views.py
+++ b/ratechecker/tests/test_views.py
@@ -144,18 +144,6 @@ class RateCheckerTestCase(APITestCase):
         # self.assertEqual(response_fixed.data.get('data').get('monthly'), 1.5)
         # self.assertTrue(response_fixed.data.get('data').get('upfront') is None)
 
-        response = self.client.get('%s-fees' % self.url, params)
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertTrue('fees' in response.data)
-        self.assertEqual(len(response.data['fees']), 3)
-
-        threshold = 0.01
-        odollar = abs(response.data['fees']['origination_dollar'] - 1608.0)
-        self.assertTrue(odollar < threshold)
-        self.assertEqual(response.data['fees']['origination_percent'], 0.0)
-        tparty = abs(response.data['fees']['third_party'] - 587.27)
-        self.assertTrue(tparty < threshold)
-
 
 @override_settings(URLCONF='ratechecker.urls')
 class RateCheckerStatusTest(APITestCase):

--- a/ratechecker/tests/test_views_rate_query.py
+++ b/ratechecker/tests/test_views_rate_query.py
@@ -142,33 +142,6 @@ class RateQueryTestCase(TestCase):
         self.assertEqual(result['data']['2.275'], 1)
         self.assertEqual(result['data']['3.705'], 2)
 
-        self.params.property_type = 'SF'
-        result = get_rates(self.params.__dict__, return_fees=True)
-        self.assertTrue('fees' in result)
-        threshold = 0.01
-        odollar = abs(result['fees']['origination_dollar'] - 1610.0)
-        tparty = abs(result['fees']['third_party'] - 589.27)
-        self.assertTrue(odollar < threshold)
-        self.assertTrue(tparty < threshold)
-
-        self.params.property_type = 'COOP'
-        result = get_rates(self.params.__dict__, return_fees=True)
-        self.assertTrue('fees' in result)
-        threshold = 0.01
-        odollar = abs(result['fees']['origination_dollar'] - 1610.0)
-        tparty = abs(result['fees']['third_party'] - 589.27)
-        self.assertTrue(odollar < threshold)
-        self.assertTrue(tparty < threshold)
-
-        self.params.property_type = 'CONDO'
-        result = get_rates(self.params.__dict__, return_fees=True)
-        self.assertTrue('fees' in result)
-        threshold = 0.01
-        odollar = abs(result['fees']['origination_dollar'] - 1608.0)
-        tparty = abs(result['fees']['third_party'] - 587.27)
-        self.assertTrue(odollar < threshold)
-        self.assertTrue(tparty < threshold)
-
         self.initialize_params({'rate_structure': 'ARM'})
         result = get_rates(self.params.__dict__)
         self.assertTrue(result)

--- a/ratechecker/tests/test_views_rate_query.py
+++ b/ratechecker/tests/test_views_rate_query.py
@@ -2,7 +2,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from ratechecker.views import get_rates
-from ratechecker.models import Region, Product, Rate, Adjustment, Fee
+from ratechecker.models import Region, Product, Rate, Adjustment
 
 from decimal import Decimal
 
@@ -68,14 +68,6 @@ class RateQueryTestCase(TestCase):
             [8, 98, 'P', '0.125', 100000, 500000, 'CONDO', 660, 780, 30, 95, 'MD'],
             [9, 99, 'P', '0.125', 100000, 500000, 'CONDO', 660, 780, 30, 95, 'MD'],
         ]
-        FEES = [
-            # plan_id, product_id, state_id, lender , single_family, condo, coop,
-            # origination_dollar, origination_percent, third_party
-            [11, 88, 'DC', 'Institution 8', 1, 1, 1, 1608.0000, .000, 587.2700],
-            [11, 88, 'DC', 'Institution 8', 1, 0, 1, 1612.0000, .000, 591.2700],
-            [10, 88, 'DC', 'Institution 8', 0, 1, 0, 1610.0000, .000, 589.2700],
-            [11, 87, 'VA', 'Institution 7', 1, 1, 1, 1610.0000, .000, 589.2700],
-        ]
         self.NOW = timezone.now()
         NOW = self.NOW
 
@@ -109,15 +101,6 @@ class RateQueryTestCase(TestCase):
                 data_timestamp=NOW
             )
             adjustment.save()
-
-        for f in FEES:
-            fee = Fee(
-                plan_id=f[0], product_id=f[1], state_id=f[2], lender=f[3], single_family=f[4],
-                condo=f[5], coop=f[6], origination_dollar=Decimal("%s" % f[7]),
-                origination_percent=Decimal("%s" % f[8]), third_party=Decimal("%s" % f[9]),
-                data_timestamp=NOW
-            )
-            fee.save()
 
     def initialize_params(self, values={}):
         """ a helper method to init params """

--- a/ratechecker/views.py
+++ b/ratechecker/views.py
@@ -122,24 +122,6 @@ def get_rates(params_data, data_load_testing=False, return_fees=False):
             data[key] = current_value + 1
 
     results = {'data': data, 'timestamp': data_timestamp}
-    if return_fees and data:
-        fees = Fee.objects.filter(plan__plan_id__in=available_rates.keys(),
-                                  state_id=params_data.get('state'))
-
-        if params_data.get('property_type', 'SF') == 'SF':
-            fees = fees.filter(single_family=True)
-        elif params_data.get('property_type', 'SF') == 'CONDO':
-            fees = fees.filter(condo=True)
-        elif params_data.get('property_type', 'SF') == 'COOP':
-            fees = fees.filter(coop=True)
-
-        averages = fees.aggregate(
-            origination_dollar=Avg('origination_dollar'),
-            origination_percent=Avg('origination_percent'),
-            third_party=Avg('third_party'))
-
-        results['fees'] = averages
-
     if not data:
         obj = Region.objects.first()
         if obj:

--- a/ratechecker/views.py
+++ b/ratechecker/views.py
@@ -5,7 +5,7 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from ratechecker.models import Region, Rate, Adjustment, Fee
+from ratechecker.models import Region, Rate, Adjustment
 from ratechecker.ratechecker_parameters import ParamsSerializer
 
 


### PR DESCRIPTION
- Update Loader class to filter out duplicate rates in loader.py
- Reduce load call_count from 5 to 4 in test_load_daily_data
- Remove the following:
1. FeeLoader Class from loader.py
2. fee from views.py and test_views.py
3. FEE, TestFeeLoader, Fee model and view tests
4. test_load_succeeds_even_if_fee_dataset_missing
