### PR TITLE
Remove python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
 language: python
 python:
-- 2.7
 - 3.6
 install:
 - pip install tox-travis
 script:
 - tox
-- python2.7 setup.py bdist_wheel --universal
+- python3.6 setup.py bdist_wheel --universal
 after_success:
 - coveralls
 deploy:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The tool is intended to be a module that runs inside a Django project, but it ca
 These instructions are for installation on a Mac with OS X Yosemite (version 10.10.x), but they could be adapted for other environments.
 
 **Dependencies**
-* [Python 2.7 or 3.6](https://www.python.org/)
+* [Python 3.6](https://www.python.org/)
 * [pip](https://pypi.python.org/pypi/pip)
 * [virtualenv](https://virtualenv.pypa.io/en/latest/)
 * [Django](https://docs.djangoproject.com/en/1.11/)

--- a/countylimits/data_collection/gather_county_data.py
+++ b/countylimits/data_collection/gather_county_data.py
@@ -1,17 +1,10 @@
 import datetime
 import os
 from collections import OrderedDict
+from csv import DictReader
+from csv import writer as Writer
 
 import requests
-import six
-
-
-if six.PY2:  # pragma: no cover
-    from unicodecsv import DictReader
-    from unicodecsv import writer as Writer
-else:  # pragma: no cover
-    from csv import DictReader
-    from csv import writer as Writer
 
 
 ERROR_MSG = "Script failed to process all files."

--- a/countylimits/models.py
+++ b/countylimits/models.py
@@ -1,7 +1,6 @@
 from django.db import models
 from localflavor.us.models import USStateField
 from localflavor.us.us_states import STATE_CHOICES
-from six import python_2_unicode_compatible, text_type
 
 
 abbr_to_name = dict(STATE_CHOICES)
@@ -14,7 +13,6 @@ http://en.wikipedia.org/wiki/FIPS_county_code
 """
 
 
-@python_2_unicode_compatible
 class State(models.Model):
     """ A basic State object. """
     state_fips = models.CharField(
@@ -28,7 +26,6 @@ class State(models.Model):
         return '%s' % abbr_to_name[self.state_abbr]
 
 
-@python_2_unicode_compatible
 class County(models.Model):
     """ A basic state county object. """
     county_fips = models.CharField(
@@ -44,7 +41,6 @@ class County(models.Model):
         return '%s (%s)' % (self.county_name, self.county_fips)
 
 
-@python_2_unicode_compatible
 class CountyLimit(models.Model):
     """ County limit object. """
     fha_limit = models.DecimalField(
@@ -78,13 +74,13 @@ class CountyLimit(models.Model):
         limits = CountyLimit.objects.filter(county__state=state_obj)
         for countylimit in limits:
             data.append(
-                {u'state': text_type(abbr_to_name[state_obj.state_abbr]),
+                {u'state': str(abbr_to_name[state_obj.state_abbr]),
                  u'county': countylimit.county.county_name,
                  u'complete_fips': u'{}{}'.format(
                      state_obj.state_fips,
                      countylimit.county.county_fips),
-                 u'gse_limit': text_type(countylimit.gse_limit),
-                 u'fha_limit': text_type(countylimit.fha_limit),
-                 u'va_limit': text_type(countylimit.va_limit)}
+                 u'gse_limit': str(countylimit.gse_limit),
+                 u'fha_limit': str(countylimit.fha_limit),
+                 u'va_limit': str(countylimit.va_limit)}
             )
         return data

--- a/countylimits/tests.py
+++ b/countylimits/tests.py
@@ -14,7 +14,7 @@ from rest_framework import status
 from django.test import TestCase
 from django.core.management import call_command
 from django.core.management.base import CommandError
-from django.utils.six import StringIO
+from io import StringIO
 
 from countylimits.models import County, CountyLimit, State
 from countylimits.management.commands import load_county_limits

--- a/ratechecker/tests/helpers.py
+++ b/ratechecker/tests/helpers.py
@@ -1,4 +1,4 @@
-from six import BytesIO
+from io import BytesIO
 from datetime import date
 from zipfile import ZipFile
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ install_requires = [
     'django-localflavor',
     'djangorestframework>=3.6,<3.9',
     'requests>=2.18,<3',
-    'six>=1.11.0,<2',
     'unicodecsv==0.14.1',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,6 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
         'Intended Audience :: Developers',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python',
         'Programming Language :: Python :: 3.6',
         'Framework :: Django',
         'Development Status :: 5 - Production/Stable',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=py{27,36}-dj{111}
+envlist=py{36}-dj{111}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -10,7 +10,6 @@ commands=
     coverage report --skip-covered
 
 basepython=
-    py27: python2.7
     py36: python3.6
 
 deps=


### PR DESCRIPTION
Since we're removing Python 2 compatibility from the consumerfinance.gov family of projects, remove python 2 from this repo.

- Remove all references to `six`
- Remove Python 2 from the Tox testing matrix
- Remove Python 2 from Travis