### PR TITLE
Don't create universal wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
 - pip install tox-travis
 script:
 - tox
-- python3.6 setup.py bdist_wheel --universal
+- python setup.py bdist_wheel
 after_success:
 - coveralls
 deploy:


### PR DESCRIPTION
Since we no longer support python 2, we no longer need to create a wheel
that is python 2 compatible.