### PR TITLE
Pin Django Rest Framework to >=3.9.1,<4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     'django-cors-headers',
     'dj-database-url>=0.4.2,<1',
     'django-localflavor',
-    'djangorestframework>=3.6,<3.9',
+    'djangorestframework>=3.9.1,<4.0',
     'requests>=2.18,<3',
     'unicodecsv==0.14.1',
 ]


### PR DESCRIPTION
This change will pin Django Rest Framework to >=3.9.1 to detail with a security issue that GitHub has flagged, and <4.0 which is the the exclusive maximum that Wagtail 2.8 currently pins (which we have to be compatible with when owning-a-home-api gets pulled into cfgov-refresh).