### PR TITLE
Replace use of "whitelist" with "allowlist"

### DIFF
--- a/countylimits/views.py
+++ b/countylimits/views.py
@@ -4,7 +4,7 @@ from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
 
-# A static whitelist of abbreviations and FIPS codes
+# A static allowlist of abbreviations and FIPS codes
 SAFE_STATE_LIST = [
     "AL",
     "AK",


### PR DESCRIPTION
This change replaces our use of the term "whitelist" with "allowlist."

"Allowlist" and "blocklist" have a clarity of meaning for which "whitelist" and "blacklist" rely on metaphor, and metaphor can encode in thought and language both historic and current forms of domination. This is an attempt to rid our codebase of two of those metaphors.