### PR TITLE
Update beautifulsoup4 version to support Wagtail 2.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 install_requires = [
-    "beautifulsoup4>=4.5.0,<4.7",
+    "beautifulsoup4>=4.5.0,<4.9",
     "Django>=1.11,<2.3",
     "django-cors-headers",
     "dj-database-url>=0.4.2,<1",


### PR DESCRIPTION
When setting `unittest-future` to use Wagtail 2.9 an error was logged due to the version of beautifulsoup4.
Error: version conflict: beautifulsoup4 4.8.2 (.tox/unittest-current/lib/python3.6/site-packages) <-> beautifulsoup4<4.7,>=4.5.0 (from owning-a-home-api==0.15.0->-r cfgov-refresh/requirements/libraries.txt (line 45))

This simple update to `setup.py` makes the following change from 4.7 to 4.9.

To test this change run tox and you would see the following results:
```
lint installdeps: black, flake8, isort
lint installed: appdirs==1.4.4,attrs==19.3.0,beautifulsoup4==4.8.2,black==19.10b0,certifi==2020.6.20,chardet==3.0.4,click==7.1.2,coverage==4.5.4,dj-database-url==0.5.0,Django==2.2.13,django-cors-headers==3.4.0,django-localflavor==3.0.1,djangorestframework==3.11.0,flake8==3.8.3,idna==2.9,importlib-metadata==1.6.1,isort==4.3.21,mccabe==0.6.1,mock==2.0.0,model-mommy==1.6.0,-e git+https://github.com/cfpb/owning-a-home-api.git@30fe9bb56ead58c44881b69bd50970ec5a6e3322#egg=owning_a_home_api,pathspec==0.8.0,pbr==5.4.5,pycodestyle==2.6.0,pyflakes==2.2.0,python-stdnum==1.13,pytz==2020.1,regex==2020.6.8,requests==2.24.0,six==1.15.0,soupsieve==2.0.1,sqlparse==0.3.1,toml==0.10.1,typed-ast==1.4.1,urllib3==1.25.9,zipp==3.1.0
lint run-test-pre: PYTHONHASHSEED='4276499332'
lint run-test: commands[0] | black --check countylimits oahapi ratechecker setup.py
All done! ✨ 🍰 ✨
41 files would be left unchanged.
lint run-test: commands[1] | flake8 .
lint run-test: commands[2] | isort --check-only --diff --recursive ratechecker
Skipped 1 files
py36-dj22 installdeps: Django>=2.2,<2.3
py36-dj22 installed: beautifulsoup4==4.8.2,certifi==2020.6.20,chardet==3.0.4,coverage==4.5.4,dj-database-url==0.5.0,Django==2.2.13,django-cors-headers==3.4.0,django-localflavor==3.0.1,djangorestframework==3.11.0,idna==2.9,mock==2.0.0,model-mommy==1.6.0,-e git+https://github.com/cfpb/owning-a-home-api.git@30fe9bb56ead58c44881b69bd50970ec5a6e3322#egg=owning_a_home_api,pbr==5.4.5,python-stdnum==1.13,pytz==2020.1,requests==2.24.0,six==1.15.0,soupsieve==2.0.1,sqlparse==0.3.1,urllib3==1.25.9
py36-dj22 run-test-pre: PYTHONHASHSEED='4276499332'
py36-dj22 run-test: commands[0] | coverage erase
py36-dj22 run-test: commands[1] | coverage run manage.py test
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
......................................................................................................................................................................................................
----------------------------------------------------------------------
Ran 198 tests in 7.580s

OK
Destroying test database for alias 'default'...
py36-dj22 run-test: commands[2] | coverage report --skip-covered -m
Name                              Stmts   Miss  Cover   Missing
---------------------------------------------------------------
countylimits/urls.py                  6      2    67%   6-7
ratechecker/dataset.py               52      1    98%   53
ratechecker/tests/test_views.py      81      2    98%   16-17
ratechecker/urls.py                   6      2    67%   6-7
---------------------------------------------------------------
TOTAL                              1850      7    99%

33 files skipped due to complete coverage.
______________________________________________________ summary _______________________________________________________
  lint: commands succeeded
  py36-dj22: commands succeeded
  congratulations :)
```
