### PR TITLE
Updates to support isort 5.0

### DIFF
--- a/ratechecker/dataset.py
+++ b/ratechecker/dataset.py
@@ -1,7 +1,7 @@
 import io
-import xml.etree.cElementTree as ET
 from collections import OrderedDict
 from datetime import datetime, time
+from xml.etree import cElementTree as ET
 from zipfile import ZipFile
 
 from django.utils import timezone

--- a/ratechecker/ratechecker_parameters.py
+++ b/ratechecker/ratechecker_parameters.py
@@ -1,8 +1,9 @@
 from decimal import Decimal
 
 from localflavor.us.us_states import STATE_CHOICES
-from ratechecker.models import Product
 from rest_framework import serializers
+
+from ratechecker.models import Product
 
 
 def scrub_error(error):

--- a/ratechecker/tests/management/commands/test_load_daily_data.py
+++ b/ratechecker/tests/management/commands/test_load_daily_data.py
@@ -7,6 +7,7 @@ from django.core.management.base import CommandError
 from django.test import TestCase
 
 from mock import patch
+
 from ratechecker.tests.helpers import write_sample_dataset
 
 

--- a/ratechecker/tests/test_dataset.py
+++ b/ratechecker/tests/test_dataset.py
@@ -6,6 +6,7 @@ from django.core.files.base import ContentFile
 from django.utils import timezone
 
 from mock import Mock
+
 from ratechecker.dataset import CoverSheet
 from ratechecker.tests.helpers import get_sample_dataset
 

--- a/ratechecker/tests/test_loader.py
+++ b/ratechecker/tests/test_loader.py
@@ -6,6 +6,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from model_mommy import mommy
+
 from ratechecker.loader import (
     AdjustmentLoader,
     Loader,

--- a/ratechecker/tests/test_validation.py
+++ b/ratechecker/tests/test_validation.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 from django.core.files.base import ContentFile
 
 from mock import patch
+
 from ratechecker.tests.helpers import get_sample_dataset
 from ratechecker.validation import (
     ScenarioLoader,

--- a/ratechecker/tests/test_views.py
+++ b/ratechecker/tests/test_views.py
@@ -5,10 +5,11 @@ from django.test import override_settings
 from django.utils import timezone
 
 from model_mommy import mommy
-from ratechecker.models import Adjustment, Product, Rate, Region
-from ratechecker.views import set_lock_max_min
 from rest_framework import status
 from rest_framework.test import APITestCase
+
+from ratechecker.models import Adjustment, Product, Rate, Region
+from ratechecker.views import set_lock_max_min
 
 
 try:

--- a/ratechecker/views.py
+++ b/ratechecker/views.py
@@ -2,12 +2,13 @@ from decimal import Decimal
 
 from django.db.models import Q, Sum
 
-from ratechecker.models import Adjustment, Rate, Region
-from ratechecker.ratechecker_parameters import ParamsSerializer
 from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 from rest_framework.views import APIView
+
+from ratechecker.models import Adjustment, Rate, Region
+from ratechecker.ratechecker_parameters import ParamsSerializer
 
 
 def get_rates(params_data, data_load_testing=False, return_fees=False):

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
     ],
     long_description=read_file("README.md"),
     zip_safe=False,
+    python_requires=">=3",
     install_requires=install_requires,
     setup_requires=setup_requires,
     extras_require={"docs": docs_extras, "testing": testing_extras},

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     ],
     long_description=read_file("README.md"),
     zip_safe=False,
-    python_requires=">=3",
+    python_requires=">=3.6",
     install_requires=install_requires,
     setup_requires=setup_requires,
     extras_require={"docs": docs_extras, "testing": testing_extras},

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ deps=
 commands=
     black --check countylimits oahapi ratechecker setup.py
     flake8 .
-    isort --check-only --diff --recursive ratechecker
+    isort --check-only --diff ratechecker
 
 [flake8]
 ignore=E731,W503,W504,
@@ -43,7 +43,6 @@ lines_after_imports=2
 include_trailing_comma=1
 multi_line_output=3
 skip=.tox,migrations
-not_skip=__init__.py
 use_parentheses=1
 known_django=django
 known_future_library=future


### PR DESCRIPTION
Removed `not_skip` and `recursive` from `tox.ini` to fix
TypeError: __init__() got an unexpected keyword argument 'not_skip'

## recursive
Prior to version 5.0.0, isort wouldn't automatically traverse directories. The --recursive option was necessary to tell it to do so. In 5.0.0 directories are automatically traversed for all Python files, and as such this option is no longer necessary and should simply be removed.

## not_skip
In an earlier version isort had a default skip of __init__.py. To get around that many projects wanted a way to not skip __init__.py or any other files that were automatically skipped in the future by isort. isort no longer has any default skips, so if the value here is __init__.py you can simply remove the setting.

https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/

Short description explaining the high-level reason for the pull request

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests