### PR TITLE
Support LTS + Current versions of Django

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build # Status](https://travis-ci.org/cfpb/owning-a-home-api.svg?branch=master)](https://travis-ci.org/cfpb/owning-a-home-api) [![Coverage Status](https://coveralls.io/repos/cfpb/owning-a-home-api/badge.svg?branch=master)](https://coveralls.io/r/cfpb/owning-a-home-api?branch=master)
+[![Build # Status](https://travis-ci.org/cfpb/owning-a-home-api.svg?branch=main)](https://travis-ci.org/cfpb/owning-a-home-api) [![Coverage Status](https://coveralls.io/repos/cfpb/owning-a-home-api/badge.svg?branch=main)](https://coveralls.io/r/cfpb/owning-a-home-api?branch=main)
 
 # Owning a Home API 
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     "beautifulsoup4>=4.5.0,<4.9",
-    "Django>=1.11,<2.3",
+    "Django>=1.11,<3.2",
     "django-cors-headers",
     "dj-database-url>=0.4.2,<1",
     "django-localflavor>=1.1,<3.1",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{36}-dj{22}
+envlist=lint,py{36}-dj{22,31}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -15,6 +15,7 @@ basepython=
  
 deps=
     dj22:  Django>=2.2,<2.3
+    dj31:  Django>=3.1,<3.2
 
 [testenv:lint]
 recreate=False
@@ -45,6 +46,5 @@ multi_line_output=3
 skip=.tox,migrations
 use_parentheses=1
 known_django=django
-known_future_library=future
 default_section=THIRDPARTY
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
This change updates our supported version range to the LTS release of Django (2.2) and the current release of Django (3.1).

## Additions

- Added support for Django 3.1

## Removals
- Removed support for Django 1.11