### PR TITLE
Remove CSRF middleware in settings

### DIFF
--- a/settings_for_testing.py
+++ b/settings_for_testing.py
@@ -21,7 +21,6 @@ INSTALLED_APPS = (
 MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',


### PR DESCRIPTION
We've removed CSRF from non-authenticated paths in https://github.com/cfpb/consumerfinance.gov/pull/6366. The PR removes the CSRF middleware from the standalone testing settings. 