### PR TITLE
Bump supported Django version from 5.1 to 5.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 install_requires = [
     "beautifulsoup4>=4.11.0,<5.0",
-    "Django>=5.1,<5.2",
+    "Django>=5.2,<5.3",
     "django-cors-headers",
     "dj-database-url>=2.1,<3",
     "django-localflavor>=4.0,<5.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py313-dj51
+envlist=lint,py313-dj52
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -12,7 +12,7 @@ commands=
 basepython=python3.13
 
 deps=
-    dj51:  Django>=5.1,<5.2
+    dj52:  Django>=5.2,<5.3
 
 [testenv:lint]
 recreate=False


### PR DESCRIPTION
Django 5.1 is EOL as of 12/3/2025: https://www.djangoproject.com/download/#ft2